### PR TITLE
Improve HasSync aliasing support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,9 @@ repos:
     rev: v0.12.2
     hooks:
       - id: ruff
+        args: [--fix]
       - id: ruff-format
+
   - repo: https://github.com/RobertCraigie/pyright-python
     rev: v1.1.402
     hooks:

--- a/poetry.lock
+++ b/poetry.lock
@@ -223,6 +223,21 @@ files = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.1"
+description = "execnet: rapid multi-Python deployment"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc"},
+    {file = "execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3"},
+]
+
+[package.extras]
+testing = ["hatch", "pre-commit", "pytest", "tox"]
+
+[[package]]
 name = "executing"
 version = "2.2.0"
 description = "Get the currently executing AST node of a frame, and other information"
@@ -797,6 +812,27 @@ docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1)"]
 testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88"},
+    {file = "pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1"},
+]
+
+[package.dependencies]
+execnet = ">=2.1"
+pytest = ">=7.0.0"
+
+[package.extras]
+psutil = ["psutil (>=3.0)"]
+setproctitle = ["setproctitle"]
+testing = ["filelock"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -1072,4 +1108,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12"
-content-hash = "7de0b227eff2b118a3e77dc851b370e6c36147574a59d2770c1cb4214240383d"
+content-hash = "9b345a246587c3209fb3f93a98e5ae5b5d8b3cc7acbe3c2ca979520438b6a77e"

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,2 @@
+[virtualenvs]
+in-project = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ pydantic = "^2"
 pytest = "^8.4.1"
 pytest-asyncio = "^1.0.0"
 ipykernel = "^6.29.5"
+pytest-xdist = "^3.8.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/test_synced_model.py
+++ b/test_synced_model.py
@@ -1,0 +1,130 @@
+from unittest.mock import AsyncMock, Mock
+
+import jsonpatch
+import pytest
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from ws_sync.session import Session, session_context
+from ws_sync.sync import Sync
+from ws_sync.synced_model import Synced, SyncedAsCamelCase
+
+
+class Person(SyncedAsCamelCase, BaseModel):
+    first_name: str
+    last_name: str
+
+    def model_post_init(self, context):
+        self.sync = Sync(self, key="PERSON", sync_all=True)
+
+
+class Animal(Synced, BaseModel):
+    species_name: str
+
+    def model_post_init(self, context):
+        self.sync = Sync(self, key="ANIMAL", sync_all=True)
+
+
+class CamelParent(SyncedAsCamelCase, BaseModel):
+    nick_name: str
+
+    def model_post_init(self, context):
+        self.sync = Sync(self, key="PARENT", sync_all=True)
+
+
+class CamelChild(CamelParent):
+    pass
+
+
+class PlainChild(CamelParent):
+    model_config = ConfigDict()
+
+
+# utils
+
+
+def get_patch(sync: Sync):
+    prev = sync.state_snapshot
+    sync.state_snapshot = sync._snapshot()
+    return jsonpatch.make_patch(prev, sync.state_snapshot).patch
+
+
+@pytest.fixture
+def mock_session() -> Mock:
+    session = Mock(spec=Session)
+    session.send = AsyncMock()
+    session.register_event = Mock()
+    session.register_init = Mock()
+    session.deregister_event = Mock()
+    session.is_connected = True
+
+    session_context.set(session)
+    return session
+
+
+# camelCase behavior
+
+
+def test_dump_camel_case(mock_session: Mock):
+    p = Person(first_name="John", last_name="Doe")
+    assert p.model_dump() == {"firstName": "John", "lastName": "Doe"}
+
+
+def test_snapshot_camel_case(mock_session: Mock):
+    p = Person(first_name="John", last_name="Doe")
+    assert p.sync._snapshot() == {"firstName": "John", "lastName": "Doe"}
+
+
+def test_patch_camel_case(mock_session: Mock):
+    p = Person(first_name="John", last_name="Doe")
+    p.first_name = "Jane"
+    assert get_patch(p.sync) == [
+        {"op": "replace", "path": "/firstName", "value": "Jane"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_patch_apply_camel_case(mock_session: Mock):
+    p = Person(first_name="John", last_name="Doe")
+    await p.sync._patch_state(
+        [{"op": "replace", "path": "/firstName", "value": "Jane"}]
+    )
+    assert p.first_name == "Jane"
+
+
+# snake_case behavior
+
+
+def test_dump_snake_case(mock_session: Mock):
+    a = Animal(species_name="Dog")
+    assert a.model_dump() == {"species_name": "Dog"}
+
+
+def test_snapshot_snake_case(mock_session: Mock):
+    a = Animal(species_name="Dog")
+    assert a.sync._snapshot() == {"species_name": "Dog"}
+
+
+def test_patch_snake_case(mock_session: Mock):
+    a = Animal(species_name="Dog")
+    a.species_name = "Cat"
+    assert get_patch(a.sync) == [
+        {"op": "replace", "path": "/species_name", "value": "Cat"}
+    ]
+
+
+def test_init_uses_field_names(mock_session: Mock):
+    with pytest.raises(ValidationError):
+        Person(**{"firstName": "John", "last_name": "Doe"})
+
+
+# subclass behavior
+
+
+def test_inherited_config(mock_session: Mock):
+    c = CamelChild(nick_name="X")
+    assert c.model_dump() == {"nickName": "X"}
+
+
+def test_override_config(mock_session: Mock):
+    p = PlainChild(nick_name="Y")
+    assert p.model_dump() == {"nick_name": "Y"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,51 @@
+"""
+Pytest configuration and shared fixtures for ws-sync tests.
+"""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from ws_sync.session import Session, session_context
+
+from .utils import Company, Team, User
+
+
+@pytest.fixture
+def mock_session() -> Mock:
+    """Create a mock session for testing"""
+    session = Mock(spec=Session)
+    session.send = AsyncMock()
+    session.register_event = Mock()
+    session.register_init = Mock()
+    session.deregister_event = Mock()
+    session.is_connected = True
+
+    session_context.set(session)
+    return session
+
+
+@pytest.fixture
+def sample_user() -> User:
+    """Create a sample user for testing"""
+    return User(name="John Doe", age=30, email="john@example.com")
+
+
+@pytest.fixture
+def sample_team(sample_user: User) -> Team:
+    """Create a sample team for testing"""
+    return Team(
+        name="Engineering",
+        members=[sample_user, User(name="Jane Smith", age=25)],
+        leader=sample_user,
+    )
+
+
+@pytest.fixture
+def sample_company(sample_team: Team) -> Company:
+    """Create a sample company for testing"""
+    return Company(
+        name="Tech Corp",
+        teams=[sample_team],
+        employees={"john": sample_team.members[0], "jane": sample_team.members[1]},
+    )

--- a/tests/test_partial_sync.py
+++ b/tests/test_partial_sync.py
@@ -1,0 +1,483 @@
+"""
+Tests for partial sync functionality including include= and exclude= parameters
+with both normal classes and Synced BaseModel patterns, including inheritance scenarios.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+from pydantic import BaseModel
+
+from ws_sync.sync import Sync
+from ws_sync.synced_model import Synced, SyncedAsCamelCase
+
+from .utils import get_patch
+
+# Test classes for normal (non-Pydantic) objects
+
+
+class SimpleClass:
+    """Simple class for testing partial sync"""
+
+    def __init__(self):
+        self.field1 = "value1"
+        self.field2 = "value2"
+        self.field3 = "value3"
+        self.private_field = "private"
+        self._actual_private = "underscore_private"
+
+
+class ParentClass:
+    """Parent class for inheritance testing"""
+
+    def __init__(self):
+        self.parent_field = "parent_value"
+        self.shared_field = "shared_parent"
+
+
+class ChildClass(ParentClass):
+    """Child class for inheritance testing"""
+
+    def __init__(self):
+        super().__init__()
+        self.child_field = "child_value"
+        self.shared_field = "shared_child"  # Override parent field
+
+
+# Test classes for Synced BaseModel patterns
+
+
+class SimpleModel(Synced, BaseModel):
+    """Simple Pydantic model for testing partial sync"""
+
+    field1: str
+    field2: str
+    field3: str
+    private_field: str = "private"
+
+
+class ParentModel(SyncedAsCamelCase, BaseModel):
+    """Parent Pydantic model for inheritance testing"""
+
+    parent_field: str
+    shared_field: str
+
+
+class ChildModel(ParentModel):
+    """Child Pydantic model for inheritance testing"""
+
+    child_field: str
+    # shared_field inherited from parent
+
+
+class CamelChildModel(ParentModel):
+    """Child with camel case field"""
+
+    camel_field: str
+    snake_case_field: str
+
+
+# Test classes use utilities from .utils module
+
+
+class TestPartialSyncNormalClasses:
+    """Test partial sync with normal (non-Pydantic) classes"""
+
+    def test_include_specific_fields(self, mock_session: Mock):
+        """Test including only specific fields"""
+        obj = SimpleClass()
+        sync = Sync(obj, key="TEST", include={"field1": ..., "field2": ...})
+
+        snapshot = sync._snapshot()
+        assert "field1" in snapshot
+        assert "field2" in snapshot
+        assert "field3" not in snapshot
+        assert "private_field" not in snapshot
+
+    def test_include_with_custom_keys(self, mock_session: Mock):
+        """Test including fields with custom keys"""
+        obj = SimpleClass()
+        sync = Sync(obj, key="TEST", include={"field1": "custom_key", "field2": ...})
+
+        snapshot = sync._snapshot()
+        assert "custom_key" in snapshot
+        assert "field2" in snapshot
+        assert "field1" not in snapshot  # Should use custom key instead
+        assert "field3" not in snapshot
+
+    def test_sync_all_with_exclude(self, mock_session: Mock):
+        """Test sync_all with exclude parameter"""
+        obj = SimpleClass()
+        sync = Sync.all(obj, key="TEST", exclude=["field3", "private_field"])
+
+        snapshot = sync._snapshot()
+        assert "field1" in snapshot
+        assert "field2" in snapshot
+        assert "field3" not in snapshot
+        assert "private_field" not in snapshot
+
+    def test_sync_all_excludes_private_by_default(self, mock_session: Mock):
+        """Test that sync_all excludes private fields by default"""
+        obj = SimpleClass()
+        sync = Sync.all(obj, key="TEST")
+
+        snapshot = sync._snapshot()
+        assert "field1" in snapshot
+        assert "field2" in snapshot
+        assert "field3" in snapshot
+        # Note: private_field doesn't start with underscore so it's included
+        assert "private_field" in snapshot
+        # Fields starting with underscore are excluded by default
+        assert "_actual_private" not in snapshot
+
+    def test_inheritance_include_parent_fields(self, mock_session: Mock):
+        """Test including parent fields in child class"""
+        obj = ChildClass()
+        sync = Sync(obj, key="TEST", include={"parent_field": ..., "child_field": ...})
+
+        snapshot = sync._snapshot()
+        assert "parent_field" in snapshot
+        assert "child_field" in snapshot
+        assert "shared_field" not in snapshot
+
+    def test_inheritance_include_overridden_fields(self, mock_session: Mock):
+        """Test including overridden fields shows child value"""
+        obj = ChildClass()
+        sync = Sync(obj, key="TEST", include={"shared_field": ...})
+
+        snapshot = sync._snapshot()
+        assert snapshot["shared_field"] == "shared_child"
+
+    def test_inheritance_sync_all_includes_all_fields(self, mock_session: Mock):
+        """Test that sync_all includes both parent and child fields"""
+        obj = ChildClass()
+        sync = Sync.all(obj, key="TEST")
+
+        snapshot = sync._snapshot()
+        assert "parent_field" in snapshot
+        assert "child_field" in snapshot
+        assert "shared_field" in snapshot
+        assert snapshot["shared_field"] == "shared_child"
+
+    def test_inheritance_sync_all_with_exclude_parent(self, mock_session: Mock):
+        """Test excluding parent fields from child class"""
+        obj = ChildClass()
+        sync = Sync.all(obj, key="TEST", exclude=["parent_field"])
+
+        snapshot = sync._snapshot()
+        assert "parent_field" not in snapshot
+        assert "child_field" in snapshot
+        assert "shared_field" in snapshot
+
+    def test_inheritance_sync_all_with_exclude_child(self, mock_session: Mock):
+        """Test excluding child fields"""
+        obj = ChildClass()
+        sync = Sync.all(obj, key="TEST", exclude=["child_field"])
+
+        snapshot = sync._snapshot()
+        assert "parent_field" in snapshot
+        assert "child_field" not in snapshot
+        assert "shared_field" in snapshot
+
+
+class TestPartialSyncPydanticModels:
+    """Test partial sync with Synced BaseModel patterns"""
+
+    def test_include_specific_fields(self, mock_session: Mock):
+        """Test including only specific fields with Pydantic models"""
+        obj = SimpleModel(field1="val1", field2="val2", field3="val3")
+        sync = Sync(obj, key="TEST", include={"field1": ..., "field2": ...})
+
+        snapshot = sync._snapshot()
+        assert "field1" in snapshot
+        assert "field2" in snapshot
+        assert "field3" not in snapshot
+        assert "private_field" not in snapshot
+
+    def test_include_with_custom_keys_pydantic(self, mock_session: Mock):
+        """Test that custom keys are not allowed for Pydantic models"""
+        obj = SimpleModel(field1="val1", field2="val2", field3="val3")
+
+        # Should raise AssertionError when trying to use custom keys with Pydantic models
+        with pytest.raises(
+            AssertionError,
+            match="Custom sync key 'custom_key' for attribute 'field1' is not allowed for Pydantic models",
+        ):
+            Sync(obj, key="TEST", include={"field1": "custom_key", "field2": ...})
+
+    def test_sync_all_with_exclude_pydantic(self, mock_session: Mock):
+        """Test sync_all with exclude parameter for Pydantic models"""
+        obj = SimpleModel(field1="val1", field2="val2", field3="val3")
+        sync = Sync.all(obj, key="TEST", exclude=["field3", "private_field"])
+
+        snapshot = sync._snapshot()
+        assert "field1" in snapshot
+        assert "field2" in snapshot
+        assert "field3" not in snapshot
+        assert "private_field" not in snapshot
+
+    def test_pydantic_inheritance_include_parent_fields(self, mock_session: Mock):
+        """Test including parent fields in child Pydantic model"""
+        obj = ChildModel(
+            parent_field="parent", shared_field="shared", child_field="child"
+        )
+        sync = Sync(obj, key="TEST", include={"parent_field": ..., "child_field": ...})
+
+        snapshot = sync._snapshot()
+        assert "parentField" in snapshot  # Should be camelCase
+        assert "childField" in snapshot
+        assert "sharedField" not in snapshot
+
+    def test_pydantic_inheritance_include_overridden_fields(self, mock_session: Mock):
+        """Test including inherited fields in child Pydantic model"""
+        obj = ChildModel(
+            parent_field="parent", shared_field="child_shared", child_field="child"
+        )
+        sync = Sync(obj, key="TEST", include={"shared_field": ...})
+
+        snapshot = sync._snapshot()
+        assert snapshot["sharedField"] == "child_shared"
+
+    def test_pydantic_inheritance_sync_all_includes_all_fields(
+        self, mock_session: Mock
+    ):
+        """Test that sync_all includes both parent and child fields in Pydantic models"""
+        obj = ChildModel(
+            parent_field="parent", shared_field="shared", child_field="child"
+        )
+        sync = Sync.all(obj, key="TEST")
+
+        snapshot = sync._snapshot()
+        assert "parentField" in snapshot
+        assert "childField" in snapshot
+        assert "sharedField" in snapshot
+        assert snapshot["sharedField"] == "shared"
+
+    def test_pydantic_inheritance_sync_all_with_exclude_parent(
+        self, mock_session: Mock
+    ):
+        """Test excluding parent fields from child Pydantic model"""
+        obj = ChildModel(
+            parent_field="parent", shared_field="shared", child_field="child"
+        )
+        sync = Sync.all(obj, key="TEST", exclude=["parent_field"])
+
+        snapshot = sync._snapshot()
+        assert "parentField" not in snapshot
+        assert "childField" in snapshot
+        assert "sharedField" in snapshot
+
+    def test_pydantic_inheritance_sync_all_with_exclude_child(self, mock_session: Mock):
+        """Test excluding child fields from Pydantic model"""
+        obj = ChildModel(
+            parent_field="parent", shared_field="shared", child_field="child"
+        )
+        sync = Sync.all(obj, key="TEST", exclude=["child_field"])
+
+        snapshot = sync._snapshot()
+        assert "parentField" in snapshot
+        assert "childField" not in snapshot
+        assert "sharedField" in snapshot
+
+    def test_mixed_case_inheritance_with_include(self, mock_session: Mock):
+        """Test inheritance with mixed camelCase and snake_case fields"""
+        obj = CamelChildModel(
+            parent_field="parent",
+            shared_field="shared",
+            camel_field="camel",
+            snake_case_field="snake",
+        )
+        sync = Sync(
+            obj, key="TEST", include={"camel_field": ..., "snake_case_field": ...}
+        )
+
+        snapshot = sync._snapshot()
+        assert "camelField" in snapshot
+        assert "snakeCaseField" in snapshot
+        assert "parentField" not in snapshot
+        assert "sharedField" not in snapshot
+
+    def test_mixed_case_inheritance_exclude_snake_case(self, mock_session: Mock):
+        """Test excluding snake_case fields while keeping camelCase"""
+        obj = CamelChildModel(
+            parent_field="parent",
+            shared_field="shared",
+            camel_field="camel",
+            snake_case_field="snake",
+        )
+        sync = Sync.all(obj, key="TEST", exclude=["snake_case_field"])
+
+        snapshot = sync._snapshot()
+        assert "parentField" in snapshot
+        assert "sharedField" in snapshot
+        assert "camelField" in snapshot
+        assert "snakeCaseField" not in snapshot
+
+
+class TestPartialSyncListInclude:
+    """Test partial sync with list[str] include parameter"""
+
+    def test_include_list_normal_class(self, mock_session: Mock):
+        """Test including fields using list[str] with normal classes"""
+        obj = SimpleClass()
+        sync = Sync(obj, key="TEST", include=["field1", "field2"])
+
+        snapshot = sync._snapshot()
+        assert "field1" in snapshot
+        assert "field2" in snapshot
+        assert "field3" not in snapshot
+        assert "private_field" not in snapshot
+
+    def test_include_list_pydantic_model(self, mock_session: Mock):
+        """Test including fields using list[str] with Pydantic models"""
+        obj = SimpleModel(field1="val1", field2="val2", field3="val3")
+        sync = Sync(obj, key="TEST", include=["field1", "field2"])
+
+        snapshot = sync._snapshot()
+        assert "field1" in snapshot
+        assert "field2" in snapshot
+        assert "field3" not in snapshot
+        assert "private_field" not in snapshot
+
+    def test_include_list_with_camel_case(self, mock_session: Mock):
+        """Test list[str] include with camelCase conversion"""
+        obj = ChildModel(
+            parent_field="parent", shared_field="shared", child_field="child"
+        )
+        sync = Sync(obj, key="TEST", include=["parent_field", "child_field"])
+
+        snapshot = sync._snapshot()
+        assert "parentField" in snapshot
+        assert "childField" in snapshot
+        assert "sharedField" not in snapshot
+
+    def test_include_list_inheritance(self, mock_session: Mock):
+        """Test list[str] include with inheritance"""
+        obj = ChildClass()
+        sync = Sync(obj, key="TEST", include=["parent_field", "child_field"])
+
+        snapshot = sync._snapshot()
+        assert "parent_field" in snapshot
+        assert "child_field" in snapshot
+        assert "shared_field" not in snapshot
+
+    def test_sync_all_with_list_include(self, mock_session: Mock):
+        """Test that Sync.all() works with list[str] include parameter"""
+        obj = SimpleClass()
+        sync = Sync.all(
+            obj, key="TEST", include=["field1", "field2"], exclude=["field3"]
+        )
+
+        snapshot = sync._snapshot()
+        assert "field1" in snapshot
+        assert "field2" in snapshot
+        assert "field3" not in snapshot
+        assert "private_field" in snapshot  # Not in exclude list
+
+    def test_decorators_with_list_include(self, mock_session: Mock):
+        """Test that decorators work with list[str] include"""
+        from ws_sync.decorators import sync
+
+        # Use sync() instead of sync_all() to test include as restrictive
+        class TestClass:
+            @sync("TEST", include=["field1", "field2"])
+            def __init__(self):
+                self.field1 = "value1"
+                self.field2 = "value2"
+                self.field3 = "value3"
+
+        obj = TestClass()
+        snapshot = obj.sync._snapshot()  # type: ignore
+        assert "field1" in snapshot
+        assert "field2" in snapshot
+        assert "field3" not in snapshot
+
+
+class TestPartialSyncPatching:
+    """Test partial sync behavior with patching"""
+
+    def test_patch_only_included_fields_normal_class(self, mock_session: Mock):
+        """Test that patches only affect included fields in normal classes"""
+        obj = SimpleClass()
+        sync = Sync(obj, key="TEST", include={"field1": ..., "field2": ...})
+
+        # Change included field
+        obj.field1 = "new_value1"
+        patch = get_patch(sync)
+        assert len(patch) == 1
+        assert patch[0]["path"] == "/field1"
+        assert patch[0]["value"] == "new_value1"
+
+        # Change excluded field - should not generate patch
+        obj.field3 = "new_value3"
+        patch = get_patch(sync)
+        assert len(patch) == 0
+
+    def test_patch_only_included_fields_pydantic(self, mock_session: Mock):
+        """Test that patches only affect included fields in Pydantic models"""
+        obj = SimpleModel(field1="val1", field2="val2", field3="val3")
+        sync = Sync(obj, key="TEST", include={"field1": ..., "field2": ...})
+
+        # Change included field
+        obj.field1 = "new_value1"
+        patch = get_patch(sync)
+        assert len(patch) == 1
+        assert patch[0]["path"] == "/field1"
+        assert patch[0]["value"] == "new_value1"
+
+        # Change excluded field - should not generate patch
+        obj.field3 = "new_value3"
+        patch = get_patch(sync)
+        assert len(patch) == 0
+
+    def test_patch_excluded_fields_not_tracked(self, mock_session: Mock):
+        """Test that excluded fields are not tracked in patches"""
+        obj = SimpleClass()
+        sync = Sync.all(obj, key="TEST", exclude=["field3"])
+
+        # Change included field
+        obj.field1 = "new_value1"
+        patch = get_patch(sync)
+        assert len(patch) == 1
+        assert patch[0]["path"] == "/field1"
+
+        # Change excluded field - should not generate patch
+        obj.field3 = "new_value3"
+        patch = get_patch(sync)
+        assert len(patch) == 0
+
+    def test_patch_inheritance_included_fields(self, mock_session: Mock):
+        """Test patching inherited fields that are included"""
+        obj = ChildClass()
+        sync = Sync(obj, key="TEST", include={"parent_field": ..., "child_field": ...})
+
+        # Change parent field
+        obj.parent_field = "new_parent"
+        patch = get_patch(sync)
+        assert len(patch) == 1
+        assert patch[0]["path"] == "/parent_field"
+        assert patch[0]["value"] == "new_parent"
+
+        # Change child field
+        obj.child_field = "new_child"
+        patch = get_patch(sync)
+        assert len(patch) == 1
+        assert patch[0]["path"] == "/child_field"
+        assert patch[0]["value"] == "new_child"
+
+    def test_patch_inheritance_excluded_parent_field(self, mock_session: Mock):
+        """Test that excluded parent fields don't generate patches"""
+        obj = ChildClass()
+        sync = Sync.all(obj, key="TEST", exclude=["parent_field"])
+
+        # Change excluded parent field
+        obj.parent_field = "new_parent"
+        patch = get_patch(sync)
+        assert len(patch) == 0
+
+        # Change included child field
+        obj.child_field = "new_child"
+        patch = get_patch(sync)
+        assert len(patch) == 1
+        assert patch[0]["path"] == "/child_field"
+        assert patch[0]["value"] == "new_child"

--- a/tests/test_pydantic_sync.py
+++ b/tests/test_pydantic_sync.py
@@ -2,79 +2,22 @@
 Tests for Pydantic object syncing feature in ws-sync.
 """
 
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import Mock
 
 import pytest
-from pydantic import BaseModel
 
-from ws_sync import Session, sync_all, sync_only
-from ws_sync.session import session_context
+from ws_sync import sync_all, sync_only
 from ws_sync.sync import Sync
 
+from .utils import Company, Team, User
 
-class User(BaseModel):
-    """Test Pydantic model"""
-
-    name: str
-    age: int
-    email: str | None = None
-
-
-class Team(BaseModel):
-    """Test Pydantic model with nested structure"""
-
-    name: str
-    members: list[User]
-    leader: User | None = None
-
-
-class Company(BaseModel):
-    """Test Pydantic model with complex nesting"""
-
-    name: str
-    teams: list[Team]
-    employees: dict[str, User]
+# Test models are imported from .utils
 
 
 class TestPydanticSync:
     """Test suite for Pydantic object synchronization"""
 
-    @pytest.fixture
-    def mock_session(self) -> Mock:
-        """Create a mock session for testing"""
-        session = Mock(spec=Session)
-        session.send = AsyncMock()
-        session.register_event = Mock()
-        session.register_init = Mock()
-        session.deregister_event = Mock()
-        session.is_connected = True
-
-        # Set up context
-        session_context.set(session)
-        return session
-
-    @pytest.fixture
-    def sample_user(self) -> User:
-        """Create a sample user for testing"""
-        return User(name="John Doe", age=30, email="john@example.com")
-
-    @pytest.fixture
-    def sample_team(self, sample_user: User) -> Team:
-        """Create a sample team for testing"""
-        return Team(
-            name="Engineering",
-            members=[sample_user, User(name="Jane Smith", age=25)],
-            leader=sample_user,
-        )
-
-    @pytest.fixture
-    def sample_company(self, sample_team: Team) -> Company:
-        """Create a sample company for testing"""
-        return Company(
-            name="Tech Corp",
-            teams=[sample_team],
-            employees={"john": sample_team.members[0], "jane": sample_team.members[1]},
-        )
+    # Fixtures are imported from .utils
 
     def test_simple_pydantic_model_sync(self, mock_session: Mock, sample_user: User):
         """Test syncing a simple Pydantic model"""

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,42 @@
+"""
+Common test utilities and helper functions for ws-sync tests.
+"""
+
+import jsonpatch
+from pydantic import BaseModel
+
+from ws_sync.sync import Sync
+
+
+def get_patch(sync: Sync):
+    """Helper to get patch from sync object"""
+    prev = sync.state_snapshot
+    sync.state_snapshot = sync._snapshot()
+    return jsonpatch.make_patch(prev, sync.state_snapshot).patch
+
+
+# Test model classes used across multiple test files
+
+
+class User(BaseModel):
+    """Test Pydantic model"""
+
+    name: str
+    age: int
+    email: str | None = None
+
+
+class Team(BaseModel):
+    """Test Pydantic model with nested structure"""
+
+    name: str
+    members: list[User]
+    leader: User | None = None
+
+
+class Company(BaseModel):
+    """Test Pydantic model with complex nesting"""
+
+    name: str
+    teams: list[Team]
+    employees: dict[str, User]

--- a/ws_sync/__init__.py
+++ b/ws_sync/__init__.py
@@ -17,7 +17,8 @@ __all__ = [
     "Sync",
     "Session",
     "SessionState",
-    "HasSync",
+    "Synced",
+    "SyncedAsCamelCase",
     # globals
     "session_context",
     "get_user_session",
@@ -34,4 +35,4 @@ from .decorators import (
 from .id import get_user_session
 from .session import Session, SessionState, session_context
 from .sync import Sync
-from .synced_model import HasSync
+from .synced_model import Synced, SyncedAsCamelCase

--- a/ws_sync/decorators.py
+++ b/ws_sync/decorators.py
@@ -98,7 +98,7 @@ def sync(
     sync_all: bool = False,
     include: dict[str, str | EllipsisType] | None = None,
     exclude: list[str] | None = None,
-    toCamelCase: bool = False,
+    toCamelCase: bool | None = None,
     send_on_init: bool = True,
     expose_running_tasks: bool = False,
     logger: Logger | None = None,
@@ -141,7 +141,7 @@ def sync_all(
     key: str,
     include: dict[str, str | EllipsisType] | None = None,
     exclude: list[str] | None = None,
-    toCamelCase: bool = False,
+    toCamelCase: bool | None = None,
     send_on_init: bool = True,
     expose_running_tasks: bool = False,
     logger: Logger | None = None,
@@ -172,7 +172,7 @@ def sync_all(
 
 def sync_only(
     _key: str,
-    _toCamelCase: bool = False,
+    _toCamelCase: bool | None = None,
     _send_on_init: bool = True,
     _expose_running_tasks: bool = False,
     _logger: Logger | None = None,

--- a/ws_sync/decorators.py
+++ b/ws_sync/decorators.py
@@ -96,7 +96,7 @@ from .sync import Sync
 def sync(
     key: str,
     sync_all: bool = False,
-    include: dict[str, str | EllipsisType] | None = None,
+    include: dict[str, str | EllipsisType] | list[str] | None = None,
     exclude: list[str] | None = None,
     toCamelCase: bool | None = None,
     send_on_init: bool = True,
@@ -124,7 +124,7 @@ def sync(
                 obj=self,
                 key=key,
                 sync_all=sync_all,
-                include=include or {},
+                include=include,
                 exclude=exclude or [],
                 toCamelCase=toCamelCase,
                 send_on_init=send_on_init,
@@ -139,7 +139,7 @@ def sync(
 
 def sync_all(
     key: str,
-    include: dict[str, str | EllipsisType] | None = None,
+    include: dict[str, str | EllipsisType] | list[str] | None = None,
     exclude: list[str] | None = None,
     toCamelCase: bool | None = None,
     send_on_init: bool = True,
@@ -161,7 +161,7 @@ def sync_all(
     return sync(
         key=key,
         sync_all=True,
-        include=include or {},
+        include=include,
         exclude=exclude or [],
         toCamelCase=toCamelCase,
         send_on_init=send_on_init,

--- a/ws_sync/synced_model.py
+++ b/ws_sync/synced_model.py
@@ -1,40 +1,13 @@
-from pydantic import PrivateAttr
+from pydantic import AliasGenerator, ConfigDict, PrivateAttr
+from pydantic.alias_generators import to_camel
 
 from .sync import Sync
 
 
-class HasSync:
-    """
-    A mixin class that provides a `sync` attribute in a way that is compatible with any pydantic BaseModel subclass.
+class Synced:
+    """Mixin providing a ``sync`` attribute compatible with Pydantic models."""
 
-    Example with BaseModel:
-    ```python
-    class SyncedUser(HasSync, BaseModel):
-        name: str
-        contacts: dict[str, str]
-
-        def model_post_init(self, context):
-            # create the sync object
-            self.sync = Sync(self, key="USER", sync_all=True, toCamelCase=True)
-
-    u = SyncedUser(name="John", contacts={"email": "john@example.com", "phone": "+1234567890"})
-    await u.sync()
-    ```
-
-    Example with custom BaseModel:
-    ```python
-    class MyBaseModel(BaseModel):
-        # custom configuration
-        pass
-
-    class SyncedUser(HasSync, MyBaseModel):
-        name: str
-        contacts: dict[str, str]
-
-        def model_post_init(self, context):
-            self.sync = Sync(self, key="USER", sync_all=True, toCamelCase=True)
-    ```
-    """
+    model_config = ConfigDict()
 
     _sync: Sync = PrivateAttr()
 
@@ -45,3 +18,12 @@ class HasSync:
     @sync.setter
     def sync(self, value: Sync):
         self._sync = value
+
+
+class SyncedAsCamelCase(Synced):
+    """Synced base that serializes fields using camelCase."""
+
+    model_config = ConfigDict(
+        alias_generator=AliasGenerator(serialization_alias=to_camel),
+        serialize_by_alias=True,
+    )

--- a/ws_sync/synced_model.py
+++ b/ws_sync/synced_model.py
@@ -5,9 +5,37 @@ from .sync import Sync
 
 
 class Synced:
-    """Mixin providing a ``sync`` attribute compatible with Pydantic models."""
+    """
+    A mixin class that provides a `sync` attribute in a way that is compatible with any pydantic BaseModel subclass.
 
-    model_config = ConfigDict()
+    Example with BaseModel:
+    ```python
+    class SyncedUser(Synced, BaseModel):
+        name: str
+        contacts: dict[str, str]
+
+        def model_post_init(self, context):
+            # create the sync object
+            self.sync = Sync.all(self, key="USER")
+
+    u = SyncedUser(name="John", contacts={"email": "john@example.com", "phone": "+1234567890"})
+    await u.sync()
+    ```
+
+    Example with custom BaseModel:
+    ```python
+    class MyBaseModel(BaseModel):
+        # custom configuration
+        pass
+
+    class SyncedUser(Synced, MyBaseModel):
+        name: str
+        contacts: dict[str, str]
+
+        def model_post_init(self, context):
+            self.sync = Sync.all(self, key="USER")
+    ```
+    """
 
     _sync: Sync = PrivateAttr()
 


### PR DESCRIPTION
## Summary
- add pydantic alias generator for `HasSync`
- test `HasSync` serialization and patch behavior when using camelCase

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686abf1c9970832fa5e8ec665fa7f75d