### PR TITLE
Add on_sync callback and real-time debug CLI

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -438,6 +438,31 @@ docs = ["intersphinx-registry", "myst-parser", "pydata-sphinx-theme", "sphinx-au
 test = ["ipykernel", "pre-commit", "pytest (<9)", "pytest-cov", "pytest-timeout"]
 
 [[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+description = "Python port of markdown-it. Markdown parsing, done right!"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"},
+    {file = "markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1"},
+]
+
+[package.dependencies]
+mdurl = ">=0.1,<1.0"
+
+[package.extras]
+benchmarking = ["psutil", "pytest", "pytest-benchmark"]
+code-style = ["pre-commit (>=3.0,<4.0)"]
+compare = ["commonmark (>=0.9,<1.0)", "markdown (>=3.4,<4.0)", "mistletoe (>=1.0,<2.0)", "mistune (>=2.0,<3.0)", "panflute (>=2.3,<3.0)"]
+linkify = ["linkify-it-py (>=1,<3)"]
+plugins = ["mdit-py-plugins"]
+profiling = ["gprof2dot"]
+rtd = ["jupyter_sphinx", "mdit-py-plugins", "myst-parser", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-design", "sphinx_book_theme"]
+testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
+
+[[package]]
 name = "matplotlib-inline"
 version = "0.1.7"
 description = "Inline Matplotlib backend for Jupyter"
@@ -451,6 +476,18 @@ files = [
 
 [package.dependencies]
 traitlets = "*"
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+description = "Markdown URL utilities"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
+    {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
+]
 
 [[package]]
 name = "nest-asyncio"
@@ -761,7 +798,7 @@ version = "2.19.2"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
     {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
@@ -967,6 +1004,25 @@ files = [
 cffi = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
+name = "rich"
+version = "13.9.4"
+description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+optional = false
+python-versions = ">=3.8.0"
+groups = ["main"]
+files = [
+    {file = "rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90"},
+    {file = "rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098"},
+]
+
+[package.dependencies]
+markdown-it-py = ">=2.2.0"
+pygments = ">=2.13.0,<3.0.0"
+
+[package.extras]
+jupyter = ["ipywidgets (>=7.5.1,<9)"]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -1108,4 +1164,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12"
-content-hash = "9b345a246587c3209fb3f93a98e5ae5b5d8b3cc7acbe3c2ca979520438b6a77e"
+content-hash = "bdba9ea700a484fe73e3513f4903e8ef6f9674330df509ea1519fd3dab0396ee"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ python = ">=3.12"
 starlette = ">=0.37.2"
 jsonpatch = "^1.33"
 pydantic = "^2"
+rich = "^13.7.0"
 
 
 [tool.poetry.group.dev.dependencies]
@@ -17,6 +18,9 @@ pytest = "^8.4.1"
 pytest-asyncio = "^1.0.0"
 ipykernel = "^6.29.5"
 pytest-xdist = "^3.8.0"
+
+[tool.poetry.scripts]
+ws-sync-debug = "ws_sync.debug_cli:main"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,0 +1,26 @@
+import asyncio
+from unittest.mock import Mock
+
+import pytest
+
+from ws_sync.sync import Sync
+
+
+class Dummy:
+    def __init__(self) -> None:
+        self.value = 0
+
+
+@pytest.mark.asyncio
+async def test_on_snapshot_callback_called(mock_session: Mock):
+    obj = Dummy()
+    called = asyncio.Event()
+
+    async def cb(snapshot):
+        assert snapshot["value"] == obj.value
+        called.set()
+
+    sync = Sync(obj, key="TEST", include={"value": ...}, on_snapshot=cb)
+    obj.value = 1
+    await sync.sync()
+    assert called.is_set()

--- a/ws_sync/__init__.py
+++ b/ws_sync/__init__.py
@@ -19,11 +19,13 @@ __all__ = [
     "SessionState",
     "Synced",
     "SyncedAsCamelCase",
+    "watch_sync",
     # globals
     "session_context",
     "get_user_session",
 ]
 
+from .debug_cli import watch_sync
 from .decorators import (
     remote_action,
     remote_task,

--- a/ws_sync/debug_cli.py
+++ b/ws_sync/debug_cli.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+from collections import deque
+from time import time
+from typing import Any
+
+from rich.console import Console
+from rich.json import JSON
+from rich.live import Live
+from rich.table import Table
+
+from .sync import Sync
+
+
+async def watch_sync(sync: Sync, history: int = 20) -> None:
+    """Watch a :class:`Sync` object and display updates in real time."""
+
+    console = Console()
+    intervals: deque[float] = deque(maxlen=history)
+    last = time()
+    state: dict[str, Any] = {}
+    event = asyncio.Event()
+
+    async def on_snapshot(snapshot: dict[str, Any]) -> None:
+        nonlocal last, state
+        now = time()
+        intervals.append(now - last)
+        last = now
+        state = snapshot
+        event.set()
+
+    sync.on_snapshot = on_snapshot
+
+    def render() -> Table:
+        table = Table(show_header=False)
+        table.add_row("Δt", " ".join(f"{dt:.2f}s" for dt in intervals))
+        table.add_row("State", JSON.from_data(state))
+        return table
+
+    with Live(render(), console=console, refresh_per_second=4) as live:
+        while True:
+            await event.wait()
+            event.clear()
+            live.update(render())
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Debug a Sync instance")
+    parser.add_argument("path", help="Import path to Sync object, e.g. module:attr")
+    args = parser.parse_args()
+
+    module_name, attr = args.path.split(":")
+    module = __import__(module_name, fromlist=[attr])
+    sync = getattr(module, attr)
+    if not isinstance(sync, Sync):
+        raise SystemExit("Provided path is not a Sync instance")
+    asyncio.run(watch_sync(sync))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- allow `Sync` to accept an `on_snapshot` callback
- invoke the callback whenever sync sends state
- export `watch_sync` and add a `ws-sync-debug` script
- implement a Rich-based debug CLI
- test callback behaviour
- include `rich` in dependencies

## Testing
- `pre-commit run --files ws_sync/sync.py ws_sync/debug_cli.py ws_sync/__init__.py pyproject.toml tests/test_callbacks.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687359cc5f60832faa900f6fe306caaf